### PR TITLE
BIP-36 Silo V3 update

### DIFF
--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -29,6 +29,18 @@ contract Depot is DepotFacet, TokenSupportFacet {
         IBeanstalkTransfer(0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5);
 
     /**
+     * @dev So Depot can receive Ether.
+     */
+    receive() external payable {}
+
+    /**
+     * @dev Returns the current version of Depot.
+     */
+    function version() external pure returns (string memory) {
+        return "1.0.1";
+    }
+
+    /**
      * 
      * Farm
      * 

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -7,11 +7,11 @@ import "@openzeppelin/contracts/drafts/IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "./facets/DepotFacet.sol";
-import "./facets/TokenSupportFacet.sol";
-import "./interfaces/IBeanstalk.sol";
-import "./interfaces/IERC4494.sol";
-import "./libraries/LibFunction.sol";
+import "../beanstalk/farm/DepotFacet.sol";
+import "../beanstalk/farm/TokenSupportFacet.sol";
+import "../interfaces/IBeanstalkTransfer.sol";
+import "../interfaces/IERC4494.sol";
+import "../libraries/LibFunction.sol";
 
 /**
  * @title Depot
@@ -25,8 +25,8 @@ contract Depot is DepotFacet, TokenSupportFacet {
 
     using SafeERC20 for IERC20;
 
-    IBeanstalk private constant beanstalk =
-        IBeanstalk(0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5);
+    IBeanstalkTransfer private constant beanstalk =
+        IBeanstalkTransfer(0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5);
 
     /**
      * 
@@ -88,11 +88,11 @@ contract Depot is DepotFacet, TokenSupportFacet {
         address sender,
         address recipient,
         address token,
-        uint32 season,
+        int96 stem,
         uint256 amount
     ) external payable returns (uint256 bdv) {
         require(sender == msg.sender, "invalid sender");
-        bdv = beanstalk.transferDeposit(msg.sender, recipient, token, season, amount);
+        bdv = beanstalk.transferDeposit(msg.sender, recipient, token, stem, amount);
     }
 
     /**
@@ -103,11 +103,11 @@ contract Depot is DepotFacet, TokenSupportFacet {
         address sender,
         address recipient,
         address token,
-        uint32[] calldata seasons,
+        int96[] calldata stems,
         uint256[] calldata amounts
     ) external payable returns (uint256[] memory bdvs) {
         require(sender == msg.sender, "invalid sender");
-        bdvs = beanstalk.transferDeposits(msg.sender, recipient, token, seasons, amounts);
+        bdvs = beanstalk.transferDeposits(msg.sender, recipient, token, stems, amounts);
     }
 
     /**

--- a/contracts/Pipeline.sol
+++ b/contracts/Pipeline.sol
@@ -17,6 +17,20 @@ import "@openzeppelin/contracts/token/ERC721/ERC721Holder.sol";
  **/
 
 contract Pipeline is IPipeline, ERC1155Holder, ERC721Holder {
+
+
+    /**
+     * @dev So Pipeline can receive Ether.
+     */
+    receive() external payable {}
+
+    /**
+     * @dev Returns the current version of Pipeline.
+     */
+    function version() external pure returns (string memory) {
+        return "1.0.1";
+    }
+    
     /**
      * @notice Execute a single PipeCall.
      * Supports sending Ether through msg.value

--- a/contracts/facets/DepotFacet.sol
+++ b/contracts/facets/DepotFacet.sol
@@ -18,7 +18,7 @@ import "../libraries/LibFunction.sol";
 
 contract DepotFacet {
     address private constant PIPELINE =
-        0xb1bE0000bFdcDDc92A8290202830C4Ef689dCeaa; // TO DO: Update with final address.
+        0xb1bE0000C6B3C62749b5F0c92480146452D15423; // TO DO: Update with final address.
 
     /**
      * @notice Pipe a PipeCall through Pipeline.


### PR DESCRIPTION
With the passing of [BIP-36](https://github.com/BeanstalkFarms/Beanstalk/pull/410), The current `TransferDeposit(s)`  on depot will be unusable. This PR updates Depot to use `stem`.

